### PR TITLE
Add surface generation component

### DIFF
--- a/src/DiaStrut.Core/GeometryComponent.cs
+++ b/src/DiaStrut.Core/GeometryComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Grasshopper;
+using Grasshopper.Kernel.Data;
 using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
@@ -62,5 +63,25 @@ public class GeometryComponent
 
         throw new InvalidOperationException("Could not merge all faces into one surface.");
     }
-}
+
+    public static DataTree<Surface> CreateSurfaceFromVertices(DataTree<Point3d> tree)
+    {
+        var surfaces = new DataTree<Surface>();
+
+        for (int i = 0; i < tree.BranchCount; i++)
+        {
+            var branch = tree.Branch(i);
+            if (branch.Count != 4)
+                throw new ArgumentException("Each branch must contain exactly 4 points.");
+
+            var surface = NurbsSurface.CreateFromCorners(branch[0], branch[1], branch[2], branch[3]);
+            if (surface == null)
+                throw new InvalidOperationException("Failed to create surface from branch.");
+
+            var path = tree.Path(i);
+            surfaces.Add(surface, path);
+        }
+
+        return surfaces;
+    }
 }

--- a/src/DiaStrut.Plugin/Components/Geometry/CreateSurfaceFromVertices.cs
+++ b/src/DiaStrut.Plugin/Components/Geometry/CreateSurfaceFromVertices.cs
@@ -1,0 +1,66 @@
+using DiaStrut.Core;
+using Grasshopper;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+using System;
+using System.Collections.Generic;
+
+namespace DiaStrut.Plugin.Components.Geometry
+{
+    public class CreateSurfaceFromVertices : GH_Component
+    {
+        public CreateSurfaceFromVertices()
+          : base("CreateSurfaceFromVertices", "SFV",
+              "Create surfaces from a tree of surface vertex points (4 per surface)",
+              "DiaStrut", "Geometry")
+        {
+        }
+
+        protected override void RegisterInputParams(GH_InputParamManager pManager)
+        {
+            pManager.AddPointParameter("Vertices", "V",
+                "Tree of surface corner points (4 points per branch)", GH_ParamAccess.tree);
+        }
+
+        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+        {
+            pManager.AddSurfaceParameter("Surfaces", "S",
+                "Surfaces from vertices", GH_ParamAccess.tree);
+        }
+
+        protected override void SolveInstance(IGH_DataAccess DA)
+        {
+            GH_Structure<GH_Point> ghTree;
+            if (!DA.GetDataTree(0, out ghTree)) return;
+
+            var tree = new DataTree<Point3d>();
+            foreach (GH_Path path in ghTree.Paths)
+            {
+                var pts = ghTree.get_Branch(path);
+                var branch = new List<Point3d>();
+                foreach (var pt in pts)
+                {
+                    if (pt is GH_Point ghPt)
+                        branch.Add(ghPt.Value);
+                }
+                tree.AddRange(branch, path);
+            }
+
+            try
+            {
+                var surfaces = GeometryComponent.CreateSurfaceFromVertices(tree);
+                DA.SetDataTree(0, surfaces);
+            }
+            catch (Exception ex)
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
+            }
+        }
+
+        protected override System.Drawing.Bitmap Icon => null;
+
+        public override Guid ComponentGuid => new Guid("3AF9C4D7-69B4-424A-B3A7-CD49738AD3F4");
+    }
+}


### PR DESCRIPTION
## Summary
- add `CreateSurfaceFromVertices` helper in core for generating individual surfaces
- implement new Grasshopper component to expose this functionality
- fix extra bracket and import in `GeometryComponent`

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_688c7b31c9b88330a6384f65941034db